### PR TITLE
2 Add Right Sidebar

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -5,14 +5,21 @@
         <div
           class="grid grid-cols-12 mx-auto sm:px-6 lg:max-w-7xl lg:px-8 lg:gap-5"
         >
-          <!--    Left Sidebar    -->
           <div class="hidden md:block xs-col-span-1 xl:col-span-2">
             <div class="sticky top-0">
               <SidebarLeft />
             </div>
           </div>
           <!--    Main Content    -->
+          <main class="col-span-12 md:col-span-8 xl:col-span-6 bg-red-500">
+            <h1>hey</h1>
+          </main>
           <!--    Right Sidebar    -->
+          <div class="hidden md:block xl:col-span-4 md:col-span-3">
+            <div class="sticky top-0">
+              <SidebarRight />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/components/Sidebar/Right/PreviewCard/Item.vue
+++ b/components/Sidebar/Right/PreviewCard/Item.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import useTailwindConfig from "~/components/composables/useTailwindConfig";
+
+const { defaultTransition, twitterBorderColor } = useTailwindConfig();
+const wrapperClasses = computed(
+  () => `${defaultTransition} ${twitterBorderColor}`,
+);
+</script>
+
+<template>
+  <div
+    :class="wrapperClasses"
+    class="p-3 hover:bg-gray-100 cursor-pointer dark:hover:bg-dim-300 border-b"
+  >
+    <slot></slot>
+  </div>
+</template>

--- a/components/Sidebar/Right/PreviewCard/index.vue
+++ b/components/Sidebar/Right/PreviewCard/index.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import useTailwindConfig from "~/components/composables/useTailwindConfig";
+
+const { twitterBorderColor, defaultTransition } = useTailwindConfig();
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <div
+    :class="twitterBorderColor"
+    class="m-2 border bg-gray-50 dark:bg-dim-700 rounded-2xl overflow-hidden"
+  >
+    <h2
+      :class="twitterBorderColor"
+      class="p-3 text-xl font-extrabold text-gray-900 border-b dark:text-white"
+    >
+      {{ props.title }}
+    </h2>
+    <slot></slot>
+    <div
+      :class="defaultTransition"
+      class="p-3 text-sm text-blue-400 cursor-pointer hover:bg-gray-100 dark:hover:bg-dim-300"
+    >
+      Show more
+    </div>
+  </div>
+</template>

--- a/components/Sidebar/Right/index.vue
+++ b/components/Sidebar/Right/index.vue
@@ -1,0 +1,79 @@
+<script lang="ts" setup>
+import useTailwindConfig from "~/components/composables/useTailwindConfig";
+
+const { defaultTransition } = useTailwindConfig();
+const whatsHappeningItems = ref([
+  {
+    title: "#ItsSnowing",
+    count: "18.8k Tweets",
+  },
+  {
+    title: "CodingIsFun",
+    count: "125.2k Tweets",
+  },
+  {
+    title: "Cars",
+    count: "3.7k Tweets",
+  },
+]);
+const whoToFollowItems = ref([
+  {
+    name: "Arthur Morgan",
+    handle: "@ArthurMorgan",
+    image: "https://picsum.photos/200/200",
+  },
+  {
+    name: "John Marston",
+    handle: "@JohnMarston",
+    image: "https://picsum.photos/200/200",
+  },
+  {
+    name: "Sadie Adler",
+    handle: "@SadieAdler",
+    image: "https://picsum.photos/200/200",
+  },
+]);
+</script>
+
+<template>
+  <div class="flex flex-col">
+    <SidebarRightPreviewCard title="What’s happening">
+      <SidebarRightPreviewCardItem
+        v-for="whatsHappening in whatsHappeningItems"
+      >
+        <h3 class="font-bold text-gray-800 text-md dark:text-white">
+          {{ whatsHappening.title }}
+        </h3>
+        <p class="text-xs text-gray-400 dark:text-white">
+          {{ whatsHappening.count }}
+        </p>
+      </SidebarRightPreviewCardItem>
+    </SidebarRightPreviewCard>
+    <SidebarRightPreviewCard title="Who to follow">
+      <SidebarRightPreviewCardItem v-for="whoToFollow in whoToFollowItems">
+        <div class="flex flex-row items-center justify-between p-2">
+          <div class="flex flex-row items-center">
+            <img
+              :alt="`Profile picture of the user : ${whoToFollow.name}`"
+              :src="whoToFollow.image"
+              class="w-10 h-10 rounded-full"
+            />
+            <div class="ml-2">
+              <h3 class="text-sm font-bold text-gray-900 dark:text-white">
+                {{ whoToFollow.name }}
+              </h3>
+              <p class="text-xs text-gray-400">{{ whoToFollow.handle }}</p>
+            </div>
+          </div>
+          <button
+            :class="defaultTransition"
+            class="h-max px-4 py-2 font-bold text-xs bg-black dark:bg-white text-white dark:text-black rounded-full hover:bg-gray-700 dark:hover:bg-gray-300"
+            type="button"
+          >
+            Follow
+          </button>
+        </div>
+      </SidebarRightPreviewCardItem>
+    </SidebarRightPreviewCard>
+  </div>
+</template>

--- a/components/composables/useTailwindConfig.ts
+++ b/components/composables/useTailwindConfig.ts
@@ -1,5 +1,6 @@
 export default () => {
   return {
     defaultTransition: "transition ease-in-out duration-350",
+    twitterBorderColor: "border-white-200 dark:border-gray-700",
   };
 };


### PR DESCRIPTION
This pull request introduces several updates to the right sidebar component and the main content layout in the application. The changes include adding new components, updating the layout, and enhancing the styling using Tailwind CSS.

### Updates to the right sidebar:

* [`components/Sidebar/Right/PreviewCard/Item.vue`](diffhunk://#diff-49d39c0be8aabce05252125f253e68a16007905fb96e963aa9e23571d0e3df32R1-R17): Added a new `PreviewCardItem` component with Tailwind CSS classes for styling and transitions.
* [`components/Sidebar/Right/PreviewCard/index.vue`](diffhunk://#diff-484cf48d071c876ca55384eabc7ffccc1dc36ea51381fe81f71c1b4925a7ffa2R1-R33): Added a new `PreviewCard` component to display a card with a title and a slot for content, along with Tailwind CSS classes for styling and transitions.
* [`components/Sidebar/Right/index.vue`](diffhunk://#diff-67aabb1539d175c95331b09393354ea89d44ff837c668c53532c601ce6f58e8cR1-R79): Updated the right sidebar to include "What’s happening" and "Who to follow" sections with hardcoded data and Tailwind CSS classes for styling and transitions.

### Layout and styling changes:

* [`app.vue`](diffhunk://#diff-938b83b0ccc24fcc6c84fae972964953e4b1d605b956c3975cd1f8f409d035e6L8-R22): Updated the main content layout to include a new main section with a background color and a right sidebar.
* [`components/composables/useTailwindConfig.ts`](diffhunk://#diff-1a3cecf70037447f3c50ec47585df2ff92587bf98969e6af0e009c870a745c0dR4): Added a new `twitterBorderColor` configuration to the Tailwind CSS setup.

Closes #2 